### PR TITLE
Fixing potential nil pointer dereferences

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -88,12 +88,12 @@ func getItems(w http.ResponseWriter, r *http.Request) {
 
 func addItem(w http.ResponseWriter, r *http.Request) {
 	rawBody, err := io.ReadAll(r.Body)
-	defer r.Body.Close()
 	if err != nil {
 		log.Println("Error reading body:", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer r.Body.Close()
 	var req addItemRequest
 	err = json.Unmarshal(rawBody, &req)
 	if err != nil {
@@ -140,12 +140,12 @@ func addItem(w http.ResponseWriter, r *http.Request) {
 
 func updateItem(w http.ResponseWriter, r *http.Request) {
 	rawBody, err := io.ReadAll(r.Body)
-	defer r.Body.Close()
 	if err != nil {
 		log.Println("Error reading body:", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer r.Body.Close()
 	var req updateItemRequest
 	err = json.Unmarshal(rawBody, &req)
 	if err != nil {
@@ -233,12 +233,12 @@ func getUsersWithNoneAuth(w http.ResponseWriter, r *http.Request) {
 
 func registerWithPassword(w http.ResponseWriter, r *http.Request) {
 	rawBody, err := io.ReadAll(r.Body)
-	defer r.Body.Close()
 	if err != nil {
 		log.Println("Error reading body:", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer r.Body.Close()
 
 	var req passwordRegistrationRequest
 	err = json.Unmarshal(rawBody, &req)
@@ -299,12 +299,12 @@ func addAuthMethod(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	rawBody, err := io.ReadAll(r.Body)
-	defer r.Body.Close()
 	if err != nil {
 		log.Println("Error reading body:", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer r.Body.Close()
 	var req addAuthMethodRequest
 	err = json.Unmarshal(rawBody, &req)
 	if err != nil {
@@ -334,12 +334,12 @@ func addAuthMethod(w http.ResponseWriter, r *http.Request) {
 
 func loginWithPassword(w http.ResponseWriter, r *http.Request) {
 	rawBody, err := io.ReadAll(r.Body)
-	defer r.Body.Close()
 	if err != nil {
 		log.Println("Error reading body:", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer r.Body.Close()
 
 	var req passwordLoginRequest
 	err = json.Unmarshal(rawBody, &req)
@@ -398,12 +398,12 @@ func loginCash(w http.ResponseWriter, r *http.Request) {
 
 func loginNone(w http.ResponseWriter, r *http.Request) {
 	rawBody, err := io.ReadAll(r.Body)
-	defer r.Body.Close()
 	if err != nil {
 		log.Println("Error reading body:", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer r.Body.Close()
 
 	var req noneLoginRequest
 	err = json.Unmarshal(rawBody, &req)
@@ -436,12 +436,12 @@ func loginNone(w http.ResponseWriter, r *http.Request) {
 
 func loginNFC(w http.ResponseWriter, r *http.Request) {
 	rawBody, err := io.ReadAll(r.Body)
-	defer r.Body.Close()
 	if err != nil {
 		log.Println("Error reading body:", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer r.Body.Close()
 
 	var req nfcLoginRequest
 	err = json.Unmarshal(rawBody, &req)
@@ -501,12 +501,12 @@ func buyItem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rawBody, err := io.ReadAll(r.Body)
-	defer r.Body.Close()
 	if err != nil {
 		log.Println("Error reading body:", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer r.Body.Close()
 	var req buyItemRequest
 	err = json.Unmarshal(rawBody, &req)
 	if err != nil {
@@ -654,12 +654,12 @@ func changeCredit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	rawBody, err := io.ReadAll(r.Body)
-	defer r.Body.Close()
 	if err != nil {
 		log.Println("Error reading body:", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer r.Body.Close()
 	var req changeCreditRequest
 	err = json.Unmarshal(rawBody, &req)
 	if err != nil {
@@ -685,12 +685,12 @@ func changeCredit(w http.ResponseWriter, r *http.Request) {
 
 func requestPasswordReset(w http.ResponseWriter, r *http.Request) {
 	rawBody, err := io.ReadAll(r.Body)
-	defer r.Body.Close()
 	if err != nil {
 		log.Println("Error reading body:", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer r.Body.Close()
 	var req requestPasswordResetRequest
 	err = json.Unmarshal(rawBody, &req)
 	if err != nil {
@@ -717,12 +717,12 @@ func requestPasswordReset(w http.ResponseWriter, r *http.Request) {
 
 func resetPassword(w http.ResponseWriter, r *http.Request) {
 	rawBody, err := io.ReadAll(r.Body)
-	defer r.Body.Close()
 	if err != nil {
 		log.Println("Error reading body:", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer r.Body.Close()
 	var req resetPasswordRequest
 	err = json.Unmarshal(rawBody, &req)
 	if err != nil {

--- a/items/inventar.go
+++ b/items/inventar.go
@@ -33,10 +33,10 @@ func GetALlItems(ctx context.Context, db *sql.DB) ([]Item, error) {
 	items := make([]Item, 0)
 
 	result, err := db.QueryContext(ctx, `SELECT id, name, price, image, amount, barcode FROM items`)
-	defer result.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer result.Close()
 	for result.Next() {
 		var item Item
 		var imageData []byte
@@ -52,10 +52,10 @@ func GetALlItems(ctx context.Context, db *sql.DB) ([]Item, error) {
 
 func GetItemByName(ctx context.Context, name string, db *sql.DB) (Item, error) {
 	result, err := db.QueryContext(ctx, "SELECT id, name, price, image, amount, barcode FROM items WHERE name = $1", name)
-	defer result.Close()
 	if err != nil {
 		return Item{}, err
 	}
+	defer result.Close()
 	if !result.Next() {
 		return Item{}, errors.New("no such item")
 	}
@@ -68,10 +68,10 @@ func GetItemByName(ctx context.Context, name string, db *sql.DB) (Item, error) {
 
 func GetItemById(ctx context.Context, id string, db *sql.DB) (Item, error) {
 	result, err := db.QueryContext(ctx, "SELECT id, name, price, image, amount, barcode FROM items WHERE id = $1", id)
-	defer result.Close()
 	if err != nil {
 		return Item{}, err
 	}
+	defer result.Close()
 	if !result.Next() {
 		return Item{}, errors.New("no such item")
 	}
@@ -84,10 +84,10 @@ func GetItemById(ctx context.Context, id string, db *sql.DB) (Item, error) {
 
 func GetItemByBarcode(ctx context.Context, barcode string, db *sql.DB) (Item, error) {
 	result, err := db.QueryContext(ctx, "SELECT id, name, price, image, amount, barcode FROM items WHERE barcode = $1", barcode)
-	defer result.Close()
 	if err != nil {
 		return Item{}, err
 	}
+	defer result.Close()
 	if !result.Next() {
 		return Item{}, errors.New("no such item")
 	}

--- a/transactions/transaction.go
+++ b/transactions/transaction.go
@@ -35,10 +35,10 @@ func VerifyTransactionTableExists(db *sql.DB) error {
 func GetTransactionsSince(ctx context.Context, since, until int64, db *sql.DB) ([]Transaction, error) {
 	transactions := make([]Transaction, 0)
 	result, err := db.QueryContext(ctx, "SELECT id, itemid, userid, amount, authbackend, timestamp FROM transactions WHERE timestamp > $1 AND timestamp < $2", since, until)
-	defer result.Close()
 	if err != nil {
 		return transactions, err
 	}
+	defer result.Close()
 	for result.Next() {
 		var tr Transaction
 		err = result.Scan(&tr.Id, &tr.ItemId, &tr.UserId, &tr.Amount, &tr.AuthBackend, &tr.Timestamp)

--- a/users/user.go
+++ b/users/user.go
@@ -114,10 +114,10 @@ func VerifyPasswordResetTableExists(db *sql.DB) error {
 
 func GetUserForId(ctx context.Context, id string, db *sql.DB) (User, error) {
 	result, err := db.QueryContext(ctx, "SELECT id, username, email, role, credit FROM users WHERE id = $1", id)
-	defer result.Close()
 	if err != nil {
 		return User{}, err
 	}
+	defer result.Close()
 	if !result.Next() {
 		return User{}, errors.New("no such user")
 	}
@@ -128,10 +128,10 @@ func GetUserForId(ctx context.Context, id string, db *sql.DB) (User, error) {
 
 func GetUserForUsername(ctx context.Context, username string, db *sql.DB) (User, error) {
 	result, err := db.QueryContext(ctx, "SELECT id, username, email, role, credit FROM users WHERE username = $1", username)
-	defer result.Close()
 	if err != nil {
 		return User{}, err
 	}
+	defer result.Close()
 	if !result.Next() {
 		return User{}, errors.New("no such user")
 	}
@@ -209,10 +209,10 @@ func AddAuthenticationWithTransaction(ctx context.Context, auth AuthenticationDa
 
 func GetAuthForUser(ctx context.Context, id, authtype string, db *sql.DB) (AuthenticationData, error) {
 	result, err := db.QueryContext(ctx, "SELECT user_id, type, data FROM auth WHERE user_id = $1 AND type = $2", id, authtype)
-	defer result.Close()
 	if err != nil {
 		return AuthenticationData{}, err
 	}
+	defer result.Close()
 	if !result.Next() {
 		return AuthenticationData{}, errors.New("no matching authentication available")
 	}
@@ -224,10 +224,10 @@ func GetAuthForUser(ctx context.Context, id, authtype string, db *sql.DB) (Authe
 func GetAllUsers(ctx context.Context, db *sql.DB) ([]User, error) {
 	users := make([]User, 0)
 	result, err := db.QueryContext(ctx, "SELECT id, username, email, role, credit FROM users")
-	defer result.Close()
 	if err != nil {
 		return users, err
 	}
+	defer result.Close()
 	for result.Next() {
 		var user User
 		err = result.Scan(&user.Id, &user.Username, &user.Email, &user.Role, &user.Credit)

--- a/users/utils.go
+++ b/users/utils.go
@@ -30,11 +30,11 @@ func CheckHIBP(password string) bool {
 	prefix := hash[:5]
 	suffix := hash[5:]
 	resp, err := http.DefaultClient.Get(fmt.Sprintf("https://api.pwnedpasswords.com/range/%s", prefix))
-	defer resp.Body.Close()
 	if err != nil {
 		// can't do much, fail insecurely to not disrupt functionality
 		return false
 	}
+	defer resp.Body.Close()
 	s := bufio.NewScanner(resp.Body)
 	for s.Scan() {
 		if strings.HasPrefix(s.Text(), suffix) {


### PR DESCRIPTION
By deferring <some pointer>.Close() before doing error checking, it could have happened that Close() would be called on a nil pointer, resulting in a segfault. This was fixed by deferring the call AFTER checking for potential errors.